### PR TITLE
Forms Copy Edits and Proofing

### DIFF
--- a/planning-app/src/forms/declarations/AnswersOverview.vue
+++ b/planning-app/src/forms/declarations/AnswersOverview.vue
@@ -16,7 +16,7 @@
             <p v-if="!this.hasApplicantFullName">You did not provide this information.</p>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <router-link :to="{ name: 'ApplicationContactApplicant'}"> 
+            <router-link :to="{ name: 'ApplicationContactApplicant'}">
               Change<span class="govuk-visually-hidden"> applicant name</span>
             </router-link>
           </dd>
@@ -31,7 +31,7 @@
           </dd>
           <dd class="govuk-summary-list__actions">
 
-              <router-link :to="{ name: 'ApplicationContact'}"> 
+              <router-link :to="{ name: 'ApplicationContact'}">
               Change<span class="govuk-visually-hidden"> name of agent</span>
               </router-link>
           </dd>
@@ -50,7 +50,7 @@
             <p v-if="!this.hasContactInformationAgent.hasAgent">{{this.hasContactInformationAgent.answer}}</p>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <router-link :to="{ name: 'ApplicationContactAgent'}"> 
+            <router-link :to="{ name: 'ApplicationContactAgent'}">
               Change<span class="govuk-visually-hidden"> contact information</span>
             </router-link>
           </dd>
@@ -69,7 +69,7 @@
             <p v-if="!this.hasContactInformationApplicant.hasApplicant">{{this.hasContactInformationApplicant.answer}}</p>
           </dd>
           <dd class="govuk-summary-list__actions">
-            <router-link :to="{ name: 'ApplicationContactApplicant'}"> 
+            <router-link :to="{ name: 'ApplicationContactApplicant'}">
               Change<span class="govuk-visually-hidden"> contact details</span>
             </router-link>
           </dd>
@@ -91,7 +91,7 @@
           </dd>
 
           <dd class="govuk-summary-list__actions">
-            
+
           </dd>
         </div>
         <div class="govuk-summary-list__row">
@@ -276,15 +276,15 @@
         </div>
       </dl>
 
-      <h2 class="govuk-heading-l">Support documentation</h2>
+      <h2 class="govuk-heading-l">Supporting documentation</h2>
 
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row" v-for="file in this.application.data.document_files">
-    
+
           <dd class="govuk-summary-list__value">
             {{ file.original_name }}
           </dd>
-    
+
           <dd class="govuk-summary-list__actions">
             <router-link :to="{ name: 'SupportingDocumentation'}" class="govuk-link">
               Change<span class="govuk-visually-hidden"> files</span>
@@ -312,7 +312,7 @@
         </div>
       </dl>
 
-      <h2 class="govuk-heading-l">Ownerships Certificates and Agricultural Land Declaration</h2>
+      <h2 class="govuk-heading-l">Ownership Certificates and Agricultural Land Declaration</h2>
       <dl class="govuk-summary-list">
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
@@ -354,7 +354,7 @@ export default {
     vCta
   },
   methods: {
-    navigate() {  
+    navigate() {
       router.push({ name: 'Payment' });
     },
     containsKey(obj, key ) {
@@ -362,7 +362,7 @@ export default {
         return false;
       }
       var containsKey = Object.keys(obj).includes(key) ? true : false;
-      return containsKey; 
+      return containsKey;
     }
   },
   computed: {
@@ -454,8 +454,8 @@ export default {
     hasFloorAreaAdded () {
       let answer;
       if (this.hasProposalExtension) {
-        if (this.application.data.proposal_extension.additional_floor_area 
-        && this.application.data.proposal_extension.additional_floor_area_units 
+        if (this.application.data.proposal_extension.additional_floor_area
+        && this.application.data.proposal_extension.additional_floor_area_units
         && this.application.data.proposal_extension.additional_floor_area_units.name) {
           answer = this.application.data.proposal_extension.additional_floor_area + ' ' + this.application.data.proposal_extension.additional_floor_area_units.name;
           return answer;

--- a/planning-app/src/forms/documentation/AdditionalPlans.vue
+++ b/planning-app/src/forms/documentation/AdditionalPlans.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
     <h2 class="govuk-heading-xl">Supporting documents</h2>
-    
+
     <div class="purpose-message govuk-body">
       <p class="govuk-!-font-weight-bold">All supporting documentation must:</p>
       <ul>
@@ -14,7 +14,7 @@
       </ul>
     </div>
 
-    <h4 class="govuk-heading-m">Uploading aditional documents</h4>
+    <h4 class="govuk-heading-m">Uploading additional documents</h4>
 
     <p>You must submit enough documentation to understand your proposal, including information about the existing property. </p>
 
@@ -54,8 +54,8 @@ You should include elevations for all sides of the proposal.</p>
         <span class="govuk-warning-text__assistive">Warning</span>
         You must upload single page documents only
       </strong>
-    </div> 
-    
+    </div>
+
     <p>
       Select what this document includes.
     </p>
@@ -183,7 +183,7 @@ export default {
         } else {
           this.additionalPlans.push(response.data);
         }
-        
+
       })
     },
     navigate() {

--- a/planning-app/src/forms/documentation/SupportingDocumentation.vue
+++ b/planning-app/src/forms/documentation/SupportingDocumentation.vue
@@ -10,6 +10,11 @@
         <li>Be clearly named</li>
       </ul>
 
+      <strong class="govuk-!-font-size-24">Personal data</strong>
+      <ul>
+        <li>Not include personal or sensitive data that you do not have consent to make public</li>
+      </ul>
+
       <strong class="govuk-!-font-size-24">Dimensions, materials, trees</strong>
       <ul>
         <li>Display key dimensions of the proposal</li>
@@ -27,7 +32,7 @@
       <strong class="govuk-!-font-size-24">File format and size</strong>
       <ul>
         <li>All files should be attached as PDF, JPG, DOC and XLS</li>
-        <li>CAD or TIF files are not accepted</li>
+        <li>CAD or TIFF files are not accepted</li>
         <li>Be less than 10MB</li>
       </ul>
 

--- a/planning-app/src/forms/payment/PaymentCheck.vue
+++ b/planning-app/src/forms/payment/PaymentCheck.vue
@@ -1,7 +1,7 @@
 <template>
 	<div>
 		<h1 class="govuk-heading-xl" v-if="loadingCheck">
-      We're verifying the payment.
+      We are verifying your payment.
 		</h1>
 
     <error-message v-if="showErrorMessage && !loading" :message="errorMessages.APPLICATION_SUBMISSION.GENERIC_ERROR"></error-message>
@@ -51,7 +51,7 @@ export default {
           submission.data = {
               "submitted": true
           };
-          
+
           this.$store.dispatch('submitApplication', submission).then((res) => {
             if (res.error) {
               this.loadingCheck = false;
@@ -68,4 +68,3 @@ export default {
   }
 }
 </script>
-

--- a/planning-app/src/forms/payment/PaymentSuccessful.vue
+++ b/planning-app/src/forms/payment/PaymentSuccessful.vue
@@ -17,7 +17,7 @@
     <p>We receive a large volume of applications so please bear with us while we review your application. Your application will now move through two stages of processing.</p>
 
 		<h3 class="govuk-heading-m">1. Validation</h3>
-		<p>We will first determine if your application can be validated. This means we assess to see if you have submitted all the information we need to make a decision. If there is something missing you will have an opportunity to submit additional information/documents. We will contact you if this is required. Once your application has been validated you will be notified.</p>
+		<p>We will first determine if your application can be validated. This means we assess to see if you have submitted all the information we need to make a decision. If there is something missing you will have an opportunity to submit additional information / documents. We will contact you if this is required. Once your application has been validated you will be notified.</p>
 
 		<h3 class="govuk-heading-m">2. Review</h3>
 		<p>At this point we have 8 weeks to review your application and reach a decision. A planning officer will be assigned to your application. They will be in touch if they have questions or require further information. During this period we will conduct a period of consultation.</p>

--- a/planning-app/src/forms/surroundings/Trees.vue
+++ b/planning-app/src/forms/surroundings/Trees.vue
@@ -15,7 +15,7 @@
         </span>
       </summary>
       <div class="govuk-details__text">
-        <img class="location" src="../../assets/img/trees_explanation.png" alt="How to measure trees" />
+        <img class="location" src="../../assets/img/trees_explanation.png" alt="How to measure trees. Step 1. Measure the diameter of the tree at 1.5 metres up from the ground. Step 2. If the tree's diameter is greater than 75mm or 7.5cm at this height. Step 3. Measure the distance of each tree from the perimeter of your works." />
       </div>
     </details>
 
@@ -178,9 +178,9 @@ export default {
 			};
       const extensionId = this.$store.getters.getExtensionId(this.applicationId);
 
-      this.$store.dispatch('updateExtensionProposal', { 
-				"application_id": this.applicationId, 
-				'selectedProposals': payload, 
+      this.$store.dispatch('updateExtensionProposal', {
+				"application_id": this.applicationId,
+				'selectedProposals': payload,
 				"extension_id": extensionId }).then((response) => {
         if (response.error) {
 					this.showErrorMessage = true;
@@ -200,7 +200,7 @@ export default {
 						return;
 					} else {
 						this.updateProposal();
-					} 
+					}
 				})
 			}
     }

--- a/planning-app/src/forms/works/AboutChangesToOriginalHouse.vue
+++ b/planning-app/src/forms/works/AboutChangesToOriginalHouse.vue
@@ -28,7 +28,7 @@
       </fieldset>
     </div>
     <free-description></free-description>
-    
+
     <error-message v-if="showErrorMessage && !loading" :message="errorMessages.CHANGES_TO_THE_ORIGINAL_HOUSE.GENERIC_ERROR"></error-message>
 
 		<v-cta name="Continue" :onClick="submit"></v-cta>
@@ -59,7 +59,7 @@ export default {
         {
           id: 'single_storey_extension',
           value: 'single_storey_extension',
-          name: 'Single storey extension (including conservatory)'
+          name: 'Single storey extension (including conservatories)'
         },
         {
           id: 'two_storey_extension',
@@ -152,7 +152,7 @@ export default {
 
       if (this.application.data.proposal_extension.original_house.cladding) {
         this.selectedProposal.push('cladding');
-      }   
+      }
 		},
     updateNavigation () {
       var navigationInfo = {
@@ -185,10 +185,10 @@ export default {
 
       const extensionId = this.$store.getters.getExtensionId(this.applicationId);
 
-      this.$store.dispatch('updateExtensionProposal', { 
-        "application_id": this.applicationId, 
-        "selectedProposals": payload, 
-        "extension_id": extensionId 
+      this.$store.dispatch('updateExtensionProposal', {
+        "application_id": this.applicationId,
+        "selectedProposals": payload,
+        "extension_id": extensionId
       }).then((response) => {
 
         if (response.error) {

--- a/planning-app/src/messages/errorMessages.js
+++ b/planning-app/src/messages/errorMessages.js
@@ -1,11 +1,11 @@
 export const RESET_PASSWORD = {
-  SAME_EMAIL : 'The confirmation email is not matching the email provided above.',
+  SAME_EMAIL : 'The email confirmation does not match the email provided above.',
   SAME_PASSWORDS : 'The passwords must be the same.',
   WRONG_LENGTH : 'Your password must have at least 8 characters.'
 }
 
 export const CREATE_ACCOUNT = {
-  SAME_EMAIL : 'The confirmation email is not matching the email provided above.',
+  SAME_EMAIL : 'The email confirmation does not match the email provided above.',
   SAME_PASSWORDS : 'The passwords must be the same.',
   WRONG_LENGTH : 'Your password must have at least 8 characters.',
   GENERIC_ERROR : 'There has been an error. Try again later or contact us.'
@@ -106,4 +106,3 @@ export const BEDROOMS = {
 export const FLOOR_AREA = {
   GENERIC_ERROR : 'There was an error. Try again. If the problem persists please contact us.'
 }
-

--- a/planning-app/src/messages/infoMessages.js
+++ b/planning-app/src/messages/infoMessages.js
@@ -1,3 +1,3 @@
 export const WORKS_DESCRIPTION = {
-  NO_WORKS_SPECIFIED : 'You did not specifiy what are the works.'
+  NO_WORKS_SPECIFIED : 'You did not specify your works.'
 }


### PR DESCRIPTION
I've made some copy edits to the forms content include the following changes:

N.B. There are some copy changes to error and info messages detailed in a different pull request. I think also my editor has removed spaces / line breaks in some parts of the code. I havn't made any direct edits to code.

## AnswersOverview.vue
- Support documentation > Supporting documentation
- Ownerships Certificates and Agricultural Land Declaration > Ownership Certificates and Agricultural Land Declaration

## AdditionalPlans.vue
- Uploading aditional documents > Uploading additional documents

## SupportingDocumentation.vue
- Addition: Not include personal or sensitive data that you do not have consent to make public
- CAD or TIF files are not accepted > CAD or TIFF files are not accepted

## PaymentCheck.vue
- We're verifying the payment. > We are verifying your payment.

## PaymentSuccessful.vue
- Introduced a space around "information/documents" to make sure content flows correctly on screen.

## Trees.vue
- Updated the alt text for the trees image to read:
How to measure trees. Step 1. Measure the diameter of the tree at 1.5 metres up from the ground. Step 2. If the tree's diameter is greater than 75mm or 7.5cm at this height. Step 3. Measure the distance of each tree from the perimeter of your works.

## AboutChangesToOriginalHouse.vue
- Single storey extension (including conservatory) > Single storey extension (including conservatories)

